### PR TITLE
Add ability to change the file name to be an ISO Timestamp + save select box preferences

### DIFF
--- a/html/videoeditor.html
+++ b/html/videoeditor.html
@@ -58,7 +58,7 @@
             <div id="reset">Reset changes (revert to initial recording)</div>
             <label id="filename-select-label" for="filename-select">File name</label>
             <select id="filename-select">
-                <option value="random">Random filename (default)</option>
+                <option value="random">Random file name (default)</option>
                 <option value="timestamp">ISO Timestamp</option>
             </select>
         </div>

--- a/html/videoeditor.html
+++ b/html/videoeditor.html
@@ -56,6 +56,11 @@
             <div id="apply-remove">Apply</div>
             <div id="removeslider"></div>
             <div id="reset">Reset changes (revert to initial recording)</div>
+            <label id="filename-select-label" for="filename-select">File name</label>
+            <select id="filename-select">
+                <option value="random">Random filename (default)</option>
+                <option value="timestamp">ISO Timestamp</option>
+            </select>
         </div>
         <div id="export">
             <div id="export-cont">

--- a/js/convert.js
+++ b/js/convert.js
@@ -38,12 +38,12 @@ function convertStreams(videoBlob, setting) {
                 var blob = new File([result.data], 'test.gif', {
                     type: 'image/gif'
                 });
-                PostBlob(blob);
+                PostBlob('gif', blob);
             } else if (setting == "mp4") {
                 var blob = new File([result.data], 'test.mp4', {
                     type: 'video/mp4'
                 });
-                PostBlob(blob);
+                PostBlob('mp4', blob);
             }
         }
     };
@@ -71,11 +71,9 @@ function convertStreams(videoBlob, setting) {
     };
 }
 
-function PostBlob(blob) {
-    var url = URL.createObjectURL(blob);;
-    chrome.downloads.download({
-        url: url
-    });
+function PostBlob(fileType, blob) {
+    var url = URL.createObjectURL(blob);
+    triggerDownload(fileType, url);
     $("#download-label").html(chrome.i18n.getMessage("download"))
     setTimeout(() => {
         window.URL.revokeObjectURL(URL.createObjectURL(blob));

--- a/js/videoeditor.js
+++ b/js/videoeditor.js
@@ -278,7 +278,7 @@ function uuidv4() {
 function triggerDownload(extension, url) {
     const filenameType = $("#filename-select").val();
     const filename = filenameType === 'timestamp'
-        ? new Date().toISOString().replace(/:/g, '-')
+        ? new Date().toISOString().replace(/[:\.]/g, '-')
         : uuidv4();
 
     chrome.downloads.download({

--- a/js/videoeditor.js
+++ b/js/videoeditor.js
@@ -16,8 +16,31 @@ $(document).ready(function(){
     $("#format-select").niceSelect();
     $("#filename-select").niceSelect();
     $("#g-savetodrive").attr("src", url);
-    
-    
+
+    // set up saving/retrieving preferences for select boxes
+    [
+        { element: '#filename-select', key: 'filename' },
+        { element: '#format-select', key: 'format' },
+    ].forEach(selectControl => {
+        // get preference for select and set it as initial value
+        chrome.storage.sync.get([selectControl.key], function (result) {
+            if (result[selectControl.key]) {
+                $(selectControl.element).val(result[selectControl.key]);
+                $(selectControl.element).niceSelect('update');
+            }
+        });
+
+        // on changing select, save the selection to user's settings
+        $(selectControl.element).on('change', e => {
+            chrome.storage.sync.set(
+                { [selectControl.key]: e.target.value },
+                () => {
+                    console.log(`Saved ${selectControl.key} value to ${e.target.value}`)
+                }
+            );
+        });
+    });
+
     // Convert seconds to timestamp
     function timestamp(value) {
         var sec_num = value;


### PR DESCRIPTION
Adds...
- the ability for users to choose what format the file name should be in - UUID or an ISO Timestamp
- saving a user's preference when they select a format or file name format, so it can be reused in the next screen recording by default

![image](https://user-images.githubusercontent.com/369825/107520497-7a314500-6b7f-11eb-82b5-d62ceb736970.png)
![image](https://user-images.githubusercontent.com/369825/107520619-9d5bf480-6b7f-11eb-8361-4c720e5ee786.png)