### PR TITLE
append iframe only if body is defined

### DIFF
--- a/js/detect.js
+++ b/js/detect.js
@@ -3,10 +3,10 @@ var iframe = document.createElement('iframe');
 iframe.style.display = "none";
 iframe.src = chrome.extension.getURL('./html/sources.html');
 iframe.allow = "camera";
-document.body.appendChild(iframe);
+document.body && document.body.appendChild(iframe);
 
 var iframe = document.createElement('iframe');
 iframe.style.display = "none";
 iframe.src = chrome.extension.getURL('./html/audiosources.html');
 iframe.allow = "microphone";
-document.body.appendChild(iframe);
+document.body && document.body.appendChild(iframe);


### PR DESCRIPTION
We see an error in the extension if any page is aborted during load or fails to load.