### PR TITLE
Remove the CSS code that is breaking UI

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -9,9 +9,7 @@
 #screenity-screen-recorder-extension * {
     pointer-events: unset;
 }
-#screenity-screen-recorder-extension *:not(.pcr-app *):not(#pen-slider *) {
-    all: unset;
-}
+
 #screenity-screen-recorder-extension #wrap-iframe {
     position: fixed;
     border-radius: 50%;


### PR DESCRIPTION
Fixes #60 

@alyssaxuu Noticed that this line is breaking the injected css while recording.
```
#screenity-screen-recorder-extension *:not(.pcr-app *):not(#pen-slider *) {	
    all: unset;	
}
```

Removed that code and tested thoroughly, It works just fine. 