### PR TITLE
FIXED: Countdown Setting Display on Popup 

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -43,7 +43,7 @@
             <label class='check'>
               <input type='checkbox' id="countdown">
               <span></span>
-                <p id='count-select'>3 <labelp id="second-label">second</labelp></p> <labelp id="countdown-label">countdown</labelp>
+                <p id='count-select'><text id='countdown-time'>3 </text><labelp id="second-label">second</labelp></p> <labelp id="countdown-label">countdown</labelp>
             </label><br>
             <label class='check'>
               <input id='persistent' type='checkbox'>

--- a/js/popup.js
+++ b/js/popup.js
@@ -20,7 +20,7 @@ $(document).ready(function(){
             $("#countdown").prop("checked", true);  
         }
         if (result.countdown_time != 3) {
-            $("#countdown-time").html(result.countdown_time);
+            $("#countdown-time").html(result.countdown_time + " ");
         }
         if (result.quality == "max") {
             $("#quality").html(chrome.i18n.getMessage("smaller_file_size"));

--- a/js/popup.js
+++ b/js/popup.js
@@ -19,6 +19,9 @@ $(document).ready(function(){
         if (result.countdown) {
             $("#countdown").prop("checked", true);  
         }
+        if (result.countdown_time != 3) {
+            $("#countdown-time").html(result.countdown_time);
+        }
         if (result.quality == "max") {
             $("#quality").html(chrome.i18n.getMessage("smaller_file_size"));
         } else {


### PR DESCRIPTION
Issue: When changing the countdown set from 3 seconds to 5/10 seconds, the new countdowns are updated to chrome.storage(). However, when exiting and reloading the popup, the changes are not shown in the popup while the settings have actually changed.

Ex: 
I change the countdown to 10 seconds. I exit and reload popup. I see the default countdown of 3 seconds instead of 10 seconds. I start recording. HOWEVER, the countdown begins from 10 instead of three.

Fix: I fixed this by creating a new element in popup.html so I can access the countdown time easily. Then in popup.js, during popup load, I adjusted the countdown time based on the current settings that have been changed.
