### PR TITLE
Fixed incorrect video generation in 131+ chrome versions due to minor issue

### DIFF
--- a/src/pages/Recorder/Recorder.jsx
+++ b/src/pages/Recorder/Recorder.jsx
@@ -201,7 +201,7 @@ const Recorder = () => {
     const handleDataAvailable = async (e) => {
       checkMaxMemory();
 
-      if (e.data.size > 0 && e.timecode) {
+      if (e.data.size > 0 && (e.timecode != null || e.timecode != undefined)) {
         try {
           const timestamp = e.timecode;
           if (hasChunks.current === false) {


### PR DESCRIPTION
With the chrome update 131, any videos recorded using the standard Tab/Window/Screen recording features were failling. This was failling as the timecode for first chunk is set as 0 and due to the minor logical issue, this chunk was being ignored when sent to the background script from the recorder.

This fixes that issue.