### PR TITLE
feat: add export sizes based on actual blob size

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -584,11 +584,11 @@
     "description": "Download WEBM label"
   },
   "downloadMP4ButtonTitle": {
-    "message": "Download as .mp4",
+    "message": "Download as .mp4 (recommended)",
     "description": "Download MP4 button"
   },
   "downloadMP4ButtonDescription": {
-    "message": "Export an .mp4 video (recommended)",
+    "message": "Export an .mp4 video",
     "description": "Download MP4 label"
   },
   "downloadGIFButtonTitle": {

--- a/src/pages/Sandbox/context/ContentState.jsx
+++ b/src/pages/Sandbox/context/ContentState.jsx
@@ -72,6 +72,8 @@ const ContentState = (props) => {
     fallback: false,
     chunkCount: 0,
     chunkIndex: 0,
+    webmFileSize: 0,
+    mp4FileSize: 0,
   };
 
   const [contentState, setContentState] = useState(defaultState);
@@ -241,6 +243,7 @@ const ContentState = (props) => {
                 setContentState((prevState) => ({
                   ...prevState,
                   webm: fixedWebm,
+                  webmFileSize: fixedWebm.size,
                   ready: true,
                 }));
                 chrome.runtime.sendMessage({ type: "recording-complete" });
@@ -276,6 +279,7 @@ const ContentState = (props) => {
             setContentState((prevState) => ({
               ...prevState,
               webm: fixedWebm,
+              webmFileSize: fixedWebm.size,
               ready: true,
             }));
             chrome.runtime.sendMessage({ type: "recording-complete" });
@@ -306,6 +310,7 @@ const ContentState = (props) => {
           setContentState((prevState) => ({
             ...prevState,
             webm: blob,
+            webmFileSize: blob.size,
             ready: true,
           }));
           chrome.runtime.sendMessage({ type: "recording-complete" });
@@ -327,6 +332,7 @@ const ContentState = (props) => {
       setContentState((prevState) => ({
         ...prevState,
         webm: blob,
+        webmFileSize: blob.size,
         ready: true,
       }));
       chrome.runtime.sendMessage({ type: "recording-complete" });
@@ -492,6 +498,7 @@ const ContentState = (props) => {
       setContentState((prevContentState) => ({
         ...prevContentState,
         blob: blob,
+        mp4FileSize: blob.size,
         mp4ready: true,
         hasBeenEdited: true,
         isFfmpegRunning: false,
@@ -638,6 +645,7 @@ const ContentState = (props) => {
     setContentState((prevState) => ({
       ...prevState,
       webm: webmVideo,
+      webmFileSize: webmVideo.size,
       ready: true,
     }));
 

--- a/src/pages/Sandbox/layout/player/RightPanel.js
+++ b/src/pages/Sandbox/layout/player/RightPanel.js
@@ -4,6 +4,7 @@ import styles from "../../styles/player/_RightPanel.module.scss";
 import JSZip from "jszip";
 
 import { ReactSVG } from "react-svg";
+import { formatFileSize } from "../../utils/formatFileSize";
 
 const URL =
   "chrome-extension://" + chrome.i18n.getMessage("@@extension_id") + "/assets/";
@@ -556,6 +557,7 @@ const RightPanel = () => {
                     </div>
                     <div className={styles.buttonDescription}>
                       {chrome.i18n.getMessage("downloadWEBMButtonDescription")}
+                      {contentState.webmFileSize > 0 && ` (${formatFileSize(contentState.webmFileSize)})`}
                     </div>
                   </div>
                   <div className={styles.buttonRight}>
@@ -595,7 +597,8 @@ const RightPanel = () => {
                           !contentState.override)
                       ? chrome.i18n.getMessage("notAvailableLabel")
                       : contentState.mp4ready && !contentState.isFfmpegRunning
-                      ? chrome.i18n.getMessage("downloadMP4ButtonDescription")
+                      ? chrome.i18n.getMessage("downloadMP4ButtonDescription") + 
+                        (contentState.mp4FileSize > 0 ? ` (${formatFileSize(contentState.mp4FileSize)})` : "")
                       : chrome.i18n.getMessage("preparingLabel")}
                   </div>
                 </div>
@@ -623,7 +626,7 @@ const RightPanel = () => {
                       {!contentState.isFfmpegRunning
                         ? chrome.i18n.getMessage(
                             "downloadWEBMButtonDescription"
-                          )
+                          ) + (contentState.webmFileSize > 0 ? ` (${formatFileSize(contentState.webmFileSize)})` : "")
                         : chrome.i18n.getMessage("preparingLabel")}
                     </div>
                   </div>

--- a/src/pages/Sandbox/utils/formatFileSize.js
+++ b/src/pages/Sandbox/utils/formatFileSize.js
@@ -1,0 +1,12 @@
+//  Format bytes into human-readable file size
+export const formatFileSize = (bytes, decimals = 1) => {
+  if (!bytes || bytes === 0) return "0 B";
+
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(decimals)) + " " + sizes[i];
+};
+
+ 


### PR DESCRIPTION
This commit solves issue #263 by adding file size tracking functionality.


### Changes Made:

- Created _formatFileSize.js_ utility to convert bytes into human-readable format (B, KB, MB, GB)
- Added `webmFileSize` and `mp4FileSize` properties to _ContentState.jsx_ to track actual blob sizes.
- Modified video reconstruction process in _ContentState.jsx_ to store actual WEBM file size when processing fixed WebM blobs
- Added MP4 file size tracking when video blobs are updated after editing operations

<img width="733" height="751" alt="image" src="https://github.com/user-attachments/assets/49bc81fc-6fa4-4935-9a89-3640fdc28dcf" />
